### PR TITLE
Fix unhandled Jellyfin failures

### DIFF
--- a/app/jellyfin_client.py
+++ b/app/jellyfin_client.py
@@ -1,13 +1,39 @@
+import logging
 import requests
 from config import JELLYFIN_URL, API_KEY
 
 HEADERS = {"X-Emby-Token": API_KEY}
 
-def get_recently_added(days=7):
-    params = {"Recursive": True, "Limit": 20, "SortBy": "DateCreated", "SortOrder": "Descending"}
-    resp = requests.get(f"{JELLYFIN_URL}/Items/Latest", headers=HEADERS, params=params)
-    return resp.json().get("Items", [])
 
-def get_most_watched(top_n=5):
-    resp = requests.get(f"{JELLYFIN_URL}/Reports/MostPlayedItems", headers=HEADERS)
-    return resp.json()[:top_n]
+def _get_json(url: str, **kwargs) -> dict:
+    """Perform a GET request and parse the JSON response.
+
+    Any network issues or JSON decoding errors are caught and an empty
+    dictionary is returned instead so the rest of the app can continue
+    to operate without crashing.
+    """
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=10, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - simple error log
+        logging.warning("Failed to fetch %s: %s", url, exc)
+        return {}
+
+def get_recently_added(days: int = 7):
+    """Return recently added items or an empty list on failure."""
+    params = {
+        "Recursive": True,
+        "Limit": 20,
+        "SortBy": "DateCreated",
+        "SortOrder": "Descending",
+    }
+    data = _get_json(f"{JELLYFIN_URL}/Items/Latest", params=params)
+    return data.get("Items", [])
+
+def get_most_watched(top_n: int = 5):
+    """Return the most watched items or an empty list on failure."""
+    data = _get_json(f"{JELLYFIN_URL}/Reports/MostPlayedItems")
+    if isinstance(data, list):
+        return data[:top_n]
+    return []


### PR DESCRIPTION
## Summary
- wrap Jellyfin API calls with an error‐handling helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PORT=8000 python app/main.py &` *(curl output then server works)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba8b095083319d7ee55ec19a48fb