### PR TITLE
Improve GUI with Jellyfin look

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,76 @@
+body {
+  font-family: "Roboto", "Segoe UI", Arial, sans-serif;
+  background: #101010;
+  color: rgba(255, 255, 255, 0.87);
+  margin: 0;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  background-color: #202020;
+  border-radius: 0.3rem;
+}
+
+header img {
+  margin-bottom: 1rem;
+}
+
+h1,
+h2 {
+  font-weight: 400;
+}
+
+a {
+  color: #00a4dc;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+form input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: #292929;
+  border: 0.16em solid #292929;
+  border-radius: 0.2em;
+  color: inherit;
+}
+
+form input:focus {
+  border-color: #00a4dc;
+}
+
+button {
+  padding: 0.6rem 1rem;
+  border-radius: 0.3rem;
+  background: #00a4dc;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #0cb0e8;
+}
+
+.flash {
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border-radius: 0.3rem;
+}
+
+.flash.success {
+  background: rgba(0, 164, 220, 0.2);
+  color: #00a4dc;
+}
+
+.flash.info {
+  background: rgba(95, 189, 247, 0.2);
+  color: #5fbdf7;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>{% block title %}JellyLetter{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <img src="{{ url_for('static', filename='Jellyletter.png') }}" alt="JellyLetter" height="60">
+    </header>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, msg in messages %}
+        <div class="flash {{ category }}">{{ msg }}</div>
+      {% endfor %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,30 +1,22 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>JellyLetter Dashboard</title>
-</head>
-<body>
-  <h1>📊 Jellyfin Stats</h1>
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% for category, msg in messages %}
-      <div class="flash {{ category }}">{{ msg }}</div>
-    {% endfor %}
-  {% endwith %}
-  <h2>New This Week</h2>
-  <ul>
-    {% for i in new_items %}
-      <li>{{ i.Name }} ({{ i.Type }})</li>
-    {% endfor %}
-  </ul>
-  <h2>Top Watched</h2>
-  <ol>
-    {% for i in top_watched %}
-      <li>{{ i.Name }} — {{ i.PlayCount }}</li>
-    {% endfor %}
-  </ol>
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1>📊 Jellyfin Stats</h1>
+<h2>New This Week</h2>
+<ul>
+  {% for i in new_items %}
+    <li>{{ i.Name }} ({{ i.Type }})</li>
+  {% endfor %}
+</ul>
+<h2>Top Watched</h2>
+<ol>
+  {% for i in top_watched %}
+    <li>{{ i.Name }} — {{ i.PlayCount }}</li>
+  {% endfor %}
+</ol>
+<p>
   <a href="{{ url_for('ui.send_now') }}">📤 Send Now</a> |
   <a href="{{ url_for('ui.settings') }}">⚙️ Settings</a> |
   <a href="{{ url_for('ui.stats') }}">📈 Stats</a>
-</body>
-</html>
+</p>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,28 +1,23 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Settings</title>
-</head>
-<body>
-  <h1>⚙️ Configuration</h1>
-  <form method="post">
-    <label>Jellyfin URL: <input name="jellyfin_url" value="{{ jellyfin_url }}"/></label><br/>
-    <label>API Key: <input name="api_key" value="{{ api_key }}"/></label><br/>
-    <hr/>
-    <h2>SMTP (ProtonMail tokens supported)</h2>
-    <label>Server: <input name="smtp_server" value="{{ smtp_server }}"/></label><br/>
-    <label>Port: <input name="smtp_port" value="{{ smtp_port }}"/></label><br/>
-    <label>User: <input name="smtp_user" value="{{ smtp_user }}"/></label><br/>
-    <label>Password / Token: <input name="smtp_pass" value="{{ smtp_pass }}"/></label><br/>
-    <label>Recipient: <input name="newsletter_to" value="{{ newsletter_to }}"/></label><br/>
-    <hr/>
-    <h2>Notifications</h2>
-    <label>Discord Webhook: <input name="discord_webhook_url" value="{{ discord_webhook_url }}"/></label><br/>
-    <label>Telegram Bot Token: <input name="telegram_bot_token" value="{{ telegram_bot_token }}"/></label><br/>
-    <label>Telegram Chat ID: <input name="telegram_chat_id" value="{{ telegram_chat_id }}"/></label><br/>
-    <button type="submit">Save</button>
-  </form>
-  <a href="{{ url_for('ui.dashboard') }}">← Back</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+<h1>⚙️ Configuration</h1>
+<form method="post">
+  <label>Jellyfin URL: <input name="jellyfin_url" value="{{ jellyfin_url }}"/></label><br/>
+  <label>API Key: <input name="api_key" value="{{ api_key }}"/></label><br/>
+  <hr/>
+  <h2>SMTP (ProtonMail tokens supported)</h2>
+  <label>Server: <input name="smtp_server" value="{{ smtp_server }}"/></label><br/>
+  <label>Port: <input name="smtp_port" value="{{ smtp_port }}"/></label><br/>
+  <label>User: <input name="smtp_user" value="{{ smtp_user }}"/></label><br/>
+  <label>Password / Token: <input name="smtp_pass" value="{{ smtp_pass }}"/></label><br/>
+  <label>Recipient: <input name="newsletter_to" value="{{ newsletter_to }}"/></label><br/>
+  <hr/>
+  <h2>Notifications</h2>
+  <label>Discord Webhook: <input name="discord_webhook_url" value="{{ discord_webhook_url }}"/></label><br/>
+  <label>Telegram Bot Token: <input name="telegram_bot_token" value="{{ telegram_bot_token }}"/></label><br/>
+  <label>Telegram Chat ID: <input name="telegram_chat_id" value="{{ telegram_chat_id }}"/></label><br/>
+  <button type="submit">Save</button>
+</form>
+<p><a href="{{ url_for('ui.dashboard') }}">← Back</a></p>
+{% endblock %}

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Newsletter Stats</title>
-</head>
-<body>
-  <h1>📈 Newsletter Log</h1>
-  <ul>
-    {% for entry in log_entries %}
-      <li>{{ entry }}</li>
-    {% endfor %}
-  </ul>
-  <a href="{{ url_for('ui.dashboard') }}">← Back</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Stats{% endblock %}
+{% block content %}
+<h1>📈 Newsletter Log</h1>
+<ul>
+  {% for entry in log_entries %}
+    <li>{{ entry }}</li>
+  {% endfor %}
+</ul>
+<p><a href="{{ url_for('ui.dashboard') }}">← Back</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create base template with logo and flash message block
- add Jellyfin-inspired CSS styling
- update dashboard, settings and stats pages to extend base layout
- refine styles using official color palette

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r app/requirements.txt`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6855d400411c83319640296d34b4c8fd